### PR TITLE
Require tests to pass before merging

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,7 +1,8 @@
 name: run-tests
-on: [push]
+on: [pull_request]
 jobs:
   build:
+    name: run tests
     runs-on: ubuntu-latest
 
     strategy:


### PR DESCRIPTION
I wanted to ensure that the tests pass before changes could be merged.
It isn't strictly required for this repo since it's just me, but I'm
desirous of learning more about how Github Actions work.

Turns out I had to give the Build a name. Once I gave it a name, I was
able to search for the name of the build and it showed up under the
Branch Protection rules.

I also had to change the event to be on pull_request.